### PR TITLE
Allow for error messages already being on the page due to server side rendering.

### DIFF
--- a/coffeescript/rails.validations.simple_form.coffee
+++ b/coffeescript/rails.validations.simple_form.coffee
@@ -31,14 +31,14 @@ ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] =
 
     bootstrap:
       add: (element, settings, message) ->
-        if element.data('valid') != false
-          wrapper_class_element = element.closest(".#{settings.wrapper_class}");
+        errorElement = element.parent().find "#{settings.error_tag}.#{settings.error_class}"
+        if not errorElement[0]?
           wrapper_tag_element = element.closest(settings.wrapper_tag)
-          wrapper_class_element.addClass(settings.wrapper_error_class)
           errorElement = $("<#{settings.error_tag}/>", { class: settings.error_class, text: message })
           wrapper_tag_element.append(errorElement)
-        else
-          element.parent().find("#{settings.error_tag}.#{settings.error_class}").text(message)
+        wrapper_class_element = element.closest(".#{settings.wrapper_class}");
+        wrapper_class_element.addClass(settings.wrapper_error_class)
+        errorElement.text message
       remove: (element, settings) ->
         wrapper_class_element = element.closest(".#{settings.wrapper_class}.#{settings.wrapper_error_class}")
         wrapper_tag_element = element.closest(settings.wrapper_tag)

--- a/test/javascript/public/test/form_builders/validateSimpleFormBootstrap.js
+++ b/test/javascript/public/test/form_builders/validateSimpleFormBootstrap.js
@@ -64,4 +64,16 @@ test('Validate error attaching and detaching', function() {
   ok(!input.parent().parent().hasClass('error'));
   ok(!label.parent().hasClass('error'));
   ok(!input.parent().find('span.help-inline')[0]);
+
+  // Validate pre-existing error blocks are re-used
+  input.parent().append($('<span class="help-inline">Error from Server</span>'))
+  // Assert my fixture
+  ok(input.parent().find('span.help-inline:contains("Error from Server")')[0]);
+  input.val('abc')
+  input.trigger('change')
+  input.trigger('focusout')
+  ok(input.parent().parent().hasClass('error'));
+  ok(label.parent().hasClass('error'));
+  ok(input.parent().find('span.help-inline:contains("is invalid")').size() === 1);
+
 });


### PR DESCRIPTION
Check for existence of error message element.  If not present, create it.
Call addClass on parent div in all cases.  Ensures class is set regardless of pre-existing state.  addClass takes care of not adding the same class multiple times.

Added test.
#11
