### PR TITLE
Work with Rails 4

### DIFF
--- a/client_side_validations-simple_form.gemspec
+++ b/client_side_validations-simple_form.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ['lib']
   gem.version       = ClientSideValidations::SimpleForm::VERSION
 
-  gem.add_dependency 'client_side_validations', '~> 3.2.5'
+  gem.add_dependency 'client_side_validations', '>= 3.2.2'
   gem.add_dependency 'simple_form', '>= 2.1.0'
 
   gem.add_development_dependency 'rails', '~> 3.2.0'

--- a/client_side_validations-simple_form.gemspec
+++ b/client_side_validations-simple_form.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |gem|
   gem.version       = ClientSideValidations::SimpleForm::VERSION
 
   gem.add_dependency 'client_side_validations', '~> 3.2.5'
-  gem.add_dependency 'simple_form', '~> 2.1.0'
+  gem.add_dependency 'simple_form', '>= 2.1.0'
 
   gem.add_development_dependency 'rails', '~> 3.2.0'
   gem.add_development_dependency 'mocha'


### PR DESCRIPTION
To work with Rails 4, I needed to upgrade simple_form to the version 3.0.0.rc, and the client_side_validations to the branch 4-0-beta, which is on version 3.2.2, so I just changed dependencies here on client_side_validations-simple_form and it worked perfectly