### PR TITLE
Correcting typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ In your Gemfile add the following:
 ```ruby
 gem 'simple_form'
 gem 'client_side_validations'
-gem 'client_side_validations-simple_form'
+gem 'client_side_validations_simple_form'
 ```
 
 Order matters here. `SimpleForm` and `ClientSideValidations` need to be


### PR DESCRIPTION
Correcting typo in the gem name, since it's `'client_side_validations_simple_form'` and not 'client_side_validations-simple_form'`