### PR TITLE
Use closest wrapper tag for finding error element

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ bin/*
 coverage
 test/log
 .byebug_history
+.idea/

--- a/coffeescript/rails.validations.simple_form.coffee
+++ b/coffeescript/rails.validations.simple_form.coffee
@@ -28,7 +28,7 @@ ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] =
 
     bootstrap:
       add: (element, settings, message) ->
-        errorElement = element.parent().find "#{settings.error_tag}.#{settings.error_class}"
+        errorElement = element.closest(settings.wrapper_tag).find "#{settings.error_tag}.#{settings.error_class}"
         if not errorElement[0]?
           wrapperTagElement = element.closest(settings.wrapper_tag)
           errorElement = $("<#{settings.error_tag}/>", { class: settings.error_class, text: message })


### PR DESCRIPTION
Hi there,

could you please check this commit? When input is nested inside input group, for example, the error message gets appended multiple times, as described in issue #21. The reason for that is that when calling `add` method, `errorElement` is not found and created anew. This update searches for `errorElement` inside closest `error_tag`, instead of input's direct parent, which aren't always the same. As the result, it allows the following code to run without problems:

	<div class="form-group">
		<label class="control-label" for="website_username">Username</label>
		<div>
			<span class="input-group col-sm-12">
			    <span class="input-group-addon"><i class="fa fa-user"></i></span>
			    <input class="form-control" type="text" name="website[username]" id="website_username">
			</span>
		</div>
	</div>