### PR TITLE
Change js tests to test better for presence/absence/count of error messages

### DIFF
--- a/test/javascript/public/test/form_builders/validateSimpleForm.js
+++ b/test/javascript/public/test/form_builders/validateSimpleForm.js
@@ -55,14 +55,14 @@ test('Validate error attaching and detaching', function() {
   input.trigger('focusout')
   ok(!input.parent().hasClass('field_with_errors'));
   ok(!label.parent().hasClass('field_with_errors'));
-  ok(!input.parent().find('span.error')[0]);
+  ok(!form.find('span.error')[0]);
 });
 
 test('Validate pre-existing error blocks are re-used', function() {
   var form = $('form#new_user'), input = form.find('input#user_name');
   var label = $('label[for="user_name"]');
 
-  input.parent().append($('<span class="error">Error from Server</span>'))
+  input.parent().append($('<span class="error small">Error from Server</span>'))
   ok(input.parent().find('span.error:contains("Error from Server")')[0]);
   input.val('abc')
   input.trigger('change')
@@ -70,4 +70,5 @@ test('Validate pre-existing error blocks are re-used', function() {
   ok(input.parent().hasClass('field_with_errors'));
   ok(label.parent().hasClass('field_with_errors'));
   ok(input.parent().find('span.error:contains("is invalid")').size() === 1);
+  ok(form.find('span.error').size() === 1);
 });

--- a/test/javascript/public/test/form_builders/validateSimpleFormBootstrap.js
+++ b/test/javascript/public/test/form_builders/validateSimpleFormBootstrap.js
@@ -100,6 +100,7 @@ for (wrapper of ['horizontal_form', 'vertical_form', 'inline_form']) {
     ok(input.parent().parent().hasClass('error'));
     ok(label.parent().hasClass('error'));
     ok(input.parent().find('span.help-inline:contains("is invalid")').size() === 1);
+    ok(form.find('span.help-inline').size() === 1);
   });
 
   test(wrapper + ' - Validate input-group', function() {


### PR DESCRIPTION
The issue is that in [Validate pre-existing error blocks are re-used](https://github.com/DavyJonesLocker/client_side_validations-simple_form/blob/de45ab62c0b2a8cfeedc59a2964a36a14ca603fe/test/javascript/public/test/form_builders/validateSimpleForm.js#L61) test, in [line 65](https://github.com/DavyJonesLocker/client_side_validations-simple_form/blob/de45ab62c0b2a8cfeedc59a2964a36a14ca603fe/test/javascript/public/test/form_builders/validateSimpleForm.js#L65), error message tag is added with class `error`, but should be added with two classes: `error small`. This causes second error tag to be created instead of reusing existing one. The real issue is that this test don't spot this; test passes despite the fact that existing error tag wasn't reused.
