### PR TITLE
Feature/jquery 3 5 0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 10.1.0 / 2020-04-10
+
+* [FEATURE] Add jQuery 3.5.0 compatibility ([#77](https://github.com/DavyJonesLocker/client_side_validations-simple_form/pull/77))
+* [ENHANCEMENT] Test against latest Ruby versions
+* [ENHANCEMENT] Update development dependencies
+
 ## 10.0.0 / 2020-03-18
 
 * [FEATURE] Fallback on `full_error` if `error` component is not found ([#75](https://github.com/DavyJonesLocker/client_side_validations-simple_form/issues/75))

--- a/dist/simple-form.bootstrap4.esm.js
+++ b/dist/simple-form.bootstrap4.esm.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations Simple Form JS (Default) - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Default) - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */

--- a/dist/simple-form.bootstrap4.esm.js
+++ b/dist/simple-form.bootstrap4.esm.js
@@ -24,7 +24,7 @@ ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
         var errorElement = wrapperElement.find(settings.error_tag + '.invalid-feedback');
 
         if (!errorElement.length) {
-          errorElement = $('<' + settings.error_tag + '/>', {
+          errorElement = $('<' + settings.error_tag + '>', {
             "class": 'invalid-feedback',
             text: message
           });

--- a/dist/simple-form.bootstrap4.js
+++ b/dist/simple-form.bootstrap4.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations Simple Form JS (Bootstrap 4) - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Bootstrap 4) - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */

--- a/dist/simple-form.bootstrap4.js
+++ b/dist/simple-form.bootstrap4.js
@@ -30,7 +30,7 @@
           var errorElement = wrapperElement.find(settings.error_tag + '.invalid-feedback');
 
           if (!errorElement.length) {
-            errorElement = $('<' + settings.error_tag + '/>', {
+            errorElement = $('<' + settings.error_tag + '>', {
               "class": 'invalid-feedback',
               text: message
             });

--- a/dist/simple-form.esm.js
+++ b/dist/simple-form.esm.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations Simple Form JS (Default) - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Default) - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */

--- a/dist/simple-form.esm.js
+++ b/dist/simple-form.esm.js
@@ -24,7 +24,7 @@ ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
         var errorElement = wrapper.find(settings.error_tag + '.' + settings.error_class.replace(/ /g, '.'));
 
         if (!errorElement.length) {
-          errorElement = $('<' + settings.error_tag + '/>', {
+          errorElement = $('<' + settings.error_tag + '>', {
             "class": settings.error_class,
             text: message
           });

--- a/dist/simple-form.js
+++ b/dist/simple-form.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations Simple Form JS (Default) - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Default) - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */

--- a/dist/simple-form.js
+++ b/dist/simple-form.js
@@ -30,7 +30,7 @@
           var errorElement = wrapper.find(settings.error_tag + '.' + settings.error_class.replace(/ /g, '.'));
 
           if (!errorElement.length) {
-            errorElement = $('<' + settings.error_tag + '/>', {
+            errorElement = $('<' + settings.error_tag + '>', {
               "class": settings.error_class,
               text: message
             });

--- a/lib/client_side_validations/simple_form/version.rb
+++ b/lib/client_side_validations/simple_form/version.rb
@@ -2,6 +2,6 @@
 
 module ClientSideValidations
   module SimpleForm
-    VERSION = '10.0.0'
+    VERSION = '10.1.0'
   end
 end

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
       "/vendor/"
     ]
   },
-  "version": "0.1.1",
+  "version": "0.1.2",
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/src/main.bootstrap4.js
+++ b/src/main.bootstrap4.js
@@ -19,7 +19,7 @@ ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
         let errorElement = wrapperElement.find(settings.error_tag + '.invalid-feedback')
 
         if (!errorElement.length) {
-          errorElement = $('<' + settings.error_tag + '/>', { class: 'invalid-feedback', text: message })
+          errorElement = $('<' + settings.error_tag + '>', { class: 'invalid-feedback', text: message })
           wrapperElement.append(errorElement)
         }
 

--- a/src/main.js
+++ b/src/main.js
@@ -19,7 +19,7 @@ ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
         let errorElement = wrapper.find(settings.error_tag + '.' + settings.error_class.replace(/ /g, '.'))
 
         if (!errorElement.length) {
-          errorElement = $('<' + settings.error_tag + '/>', { class: settings.error_class, text: message })
+          errorElement = $('<' + settings.error_tag + '>', { class: settings.error_class, text: message })
           wrapper.append(errorElement)
         }
 

--- a/test/javascript/public/test/form_builders/validateSimpleForm.js
+++ b/test/javascript/public/test/form_builders/validateSimpleForm.js
@@ -1,4 +1,13 @@
 QUnit.module('Validate SimpleForm', {
+  before: function () {
+    currentFormBuilder = window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder']
+    window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = DEFAULT_FORM_BUILDER
+  },
+
+  after: function () {
+    window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = currentFormBuilder
+  },
+
   beforeEach: function () {
     dataCsv = {
       html_settings: {
@@ -16,14 +25,14 @@ QUnit.module('Validate SimpleForm', {
     }
 
     $('#qunit-fixture')
-      .append($('<form />', {
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',
         id: 'new_user'
       }))
       .find('form')
-      .append($('<div class="input"/>'))
+      .append($('<div class="input">'))
       .find('div')
       .append($('<input />', {
         name: 'user[name]',

--- a/test/javascript/public/test/form_builders/validateSimpleFormBootstrap.js
+++ b/test/javascript/public/test/form_builders/validateSimpleFormBootstrap.js
@@ -1,4 +1,13 @@
 QUnit.module('Validate SimpleForm Bootstrap', {
+  before: function () {
+    currentFormBuilder = window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder']
+    window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = DEFAULT_FORM_BUILDER
+  },
+
+  after: function () {
+    window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = currentFormBuilder
+  },
+
   beforeEach: function () {
     dataCsv = {
       html_settings: {
@@ -17,23 +26,23 @@ QUnit.module('Validate SimpleForm Bootstrap', {
     }
 
     $('#qunit-fixture')
-      .append($('<form />', {
+      .append($('<form>', {
         action: '/users',
         'data-client-side-validations': JSON.stringify(dataCsv),
         method: 'post',
         id: 'new_user'
       }))
       .find('form')
-      .append($('<div />', {
+      .append($('<div>', {
         'class': 'form-inputs'
       }))
       .find('div')
-      .append($('<div />', {
+      .append($('<div>', {
         'class': 'control-group control-group-2 control-group-3 control-group-user-name'
       }))
       .find('div.control-group-user-name')
       .append($('<label for="user_name" class="string control-label">Name</label>'))
-      .append($('<div />', {
+      .append($('<div>', {
         'class': 'controls'
       }))
       .find('div')
@@ -42,16 +51,16 @@ QUnit.module('Validate SimpleForm Bootstrap', {
         id: 'user_name',
         type: 'text'
       }))
-      .append($('<div />', {
+      .append($('<div>', {
         'class': 'control-group control-group-2 control-group-3 control-group-user-username'
       }))
       .find('div.control-group-user-username')
       .append($('<label for="user_username" class="string control-label">Username</label>'))
-      .append($('<div />', {
+      .append($('<div>', {
         'class': 'input-group'
       }))
       .find('div')
-      .append($('<span />', {
+      .append($('<span>', {
         'class': 'input-group-addon',
         text: '@'
       }))

--- a/test/javascript/public/test/form_builders/validateSimpleFormBootstrap4.js
+++ b/test/javascript/public/test/form_builders/validateSimpleFormBootstrap4.js
@@ -1,12 +1,11 @@
 QUnit.module('Validate SimpleForm Bootstrap 4', {
   before: function () {
-    oldCSV = window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder']
-    $('body').append($('<script id="twbs4_script" src="/vendor/assets/javascripts/rails.validations.simple_form.bootstrap4.js"><\/script>'))
+    currentFormBuilder = window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder']
+    window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = BS4_FORM_BUILDER
   },
 
   after: function () {
-    $('#twbs4_script').remove()
-    window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = oldCSV
+    window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = currentFormBuilder
   },
 
   beforeEach: function () {
@@ -27,28 +26,28 @@ QUnit.module('Validate SimpleForm Bootstrap 4', {
 
     $('#qunit-fixture')
       .append(
-        $('<form />', {
+        $('<form>', {
           action: '/users',
           'data-client-side-validations': JSON.stringify(dataCsv),
           method: 'post',
           id: 'new_user'
         })
           .append(
-            $('<div />', { 'class': 'form-group' })
+            $('<div>', { 'class': 'form-group' })
               .append(
                 $('<label for="user_name" class="string form-control-label">Name</label>'))
               .append(
                 $('<input />', { 'class': 'form-control', name: 'user[name]', id: 'user_name', type: 'text' })))
           .append(
-            $('<div />', { 'class': 'form-group' })
+            $('<div>', { 'class': 'form-group' })
               .append(
                 $('<label for="user_username" class="string control-label">Username</label>'))
               .append(
-                $('<div />', { 'class': 'input-group' })
+                $('<div>', { 'class': 'input-group' })
                   .append(
-                    $('<div />', { 'class': 'input-group-prepend' })
+                    $('<div>', { 'class': 'input-group-prepend' })
                       .append(
-                        $('<span />', { 'class': 'input-group-text', text: '@' })))
+                        $('<span>', { 'class': 'input-group-text', text: '@' })))
                   .append(
                     $('<input />', { 'class': 'form-control', name: 'user[username]', id: 'user_username', type: 'text' })))))
 

--- a/test/javascript/public/test/settings.js
+++ b/test/javascript/public/test/settings.js
@@ -1,7 +1,7 @@
 QUnit.config.urlConfig.push({
   id: 'jquery',
   label: 'jQuery version',
-  value: ['3.4.1', '3.4.1.slim', '3.4.0', '3.4.0.slim', '3.3.1', '3.3.1.slim', '3.2.1', '3.2.1.slim', '3.1.1', '3.1.1.slim', '3.0.0', '3.0.0.slim', '2.2.4', '2.1.4', '2.0.3', '1.12.4', '1.11.3'],
+  value: ['3.5.0', '3.5.0.slim', '3.4.1', '3.4.1.slim', '3.3.1', '3.3.1.slim', '3.2.1', '3.2.1.slim', '3.1.1', '3.1.1.slim', '3.0.0', '3.0.0.slim', '2.2.4', '2.1.4', '2.0.3', '1.12.4', '1.11.3'],
   tooltip: 'What jQuery Core version to test against'
 })
 

--- a/test/javascript/public/test/settings.js
+++ b/test/javascript/public/test/settings.js
@@ -10,9 +10,10 @@ QUnit.config.urlConfig.push({
  */
 $(document).on('submit', function (e) {
   if (!e.isDefaultPrevented()) {
-    var form = $(e.target); var action = form.attr('action')
+    var form = $(e.target);
+    var action = form.attr('action')
     var name = 'form-frame' + jQuery.guid++
-    var iframe = $('<iframe name="' + name + '" />')
+    var iframe = $('<iframe name="' + name + '"></iframe>')
 
     if (action && action.indexOf('iframe') < 0) form.attr('action', action + '?iframe=true')
     form.attr('target', name)

--- a/test/javascript/public/test/settings.js
+++ b/test/javascript/public/test/settings.js
@@ -10,10 +10,10 @@ QUnit.config.urlConfig.push({
  */
 $(document).on('submit', function (e) {
   if (!e.isDefaultPrevented()) {
-    var form = $(e.target);
+    var form = $(e.target)
     var action = form.attr('action')
     var name = 'form-frame' + jQuery.guid++
-    var iframe = $('<iframe name="' + name + '"></iframe>')
+    var iframe = $('<iframe>', { name: name })
 
     if (action && action.indexOf('iframe') < 0) form.attr('action', action + '?iframe=true')
     form.attr('target', name)

--- a/test/javascript/server.rb
+++ b/test/javascript/server.rb
@@ -31,7 +31,7 @@ use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../
 use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../', $LOAD_PATH.find { |p| p =~ /jquery-rails/ })
 use AssetPath, urls: ['/vendor/assets/javascripts'], root: rails_validations_path.full_gem_path
 
-DEFAULT_JQUERY_VERSION = '3.4.1'
+DEFAULT_JQUERY_VERSION = '3.5.0'
 QUNIT_VERSION          = '2.9.2'
 
 helpers do

--- a/test/javascript/views/index.erb
+++ b/test/javascript/views/index.erb
@@ -4,9 +4,14 @@
 <div id="qunit-fixture"></div>
 
 <%= script_tag "https://code.jquery.com/jquery-#{jquery_version}.min.js" %>
-<%= script_tag '/vendor/assets/javascripts/jquery_ujs.js' %>
 <%= script_tag '/vendor/assets/javascripts/rails.validations.js' %>
+
 <%= script_tag '/vendor/assets/javascripts/rails.validations.simple_form.js' %>
+<script>var DEFAULT_FORM_BUILDER = window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder']</script>
+
+<%= script_tag '/vendor/assets/javascripts/rails.validations.simple_form.bootstrap4.js' %>
+<script>var BS4_FORM_BUILDER = window.ClientSideValidations.formBuilders['SimpleForm::FormBuilder']</script>
+
 <%= script_tag "https://code.jquery.com/qunit/qunit-#{qunit_version}.js" %>
 <%= script_tag 'settings' %>
 <%= test :form_builders %>

--- a/test/javascript/views/layout.erb
+++ b/test/javascript/views/layout.erb
@@ -1,11 +1,11 @@
 <!DOCTYPE html>
-<html id="html">
+<html>
   <head>
     <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width">
     <title><%= @title %></title>
     <link rel="stylesheet" href="https://code.jquery.com/qunit/qunit-<%= qunit_version %>.css">
   </head>
-
   <body>
     <%= yield %>
   </body>

--- a/vendor/assets/javascripts/rails.validations.simple_form.bootstrap4.js
+++ b/vendor/assets/javascripts/rails.validations.simple_form.bootstrap4.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations Simple Form JS (Bootstrap 4) - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Bootstrap 4) - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */

--- a/vendor/assets/javascripts/rails.validations.simple_form.bootstrap4.js
+++ b/vendor/assets/javascripts/rails.validations.simple_form.bootstrap4.js
@@ -30,7 +30,7 @@
           var errorElement = wrapperElement.find(settings.error_tag + '.invalid-feedback');
 
           if (!errorElement.length) {
-            errorElement = $('<' + settings.error_tag + '/>', {
+            errorElement = $('<' + settings.error_tag + '>', {
               "class": 'invalid-feedback',
               text: message
             });

--- a/vendor/assets/javascripts/rails.validations.simple_form.js
+++ b/vendor/assets/javascripts/rails.validations.simple_form.js
@@ -1,5 +1,5 @@
 /*!
- * Client Side Validations Simple Form JS (Default) - v0.1.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Default) - v0.1.2 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2020 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */

--- a/vendor/assets/javascripts/rails.validations.simple_form.js
+++ b/vendor/assets/javascripts/rails.validations.simple_form.js
@@ -30,7 +30,7 @@
           var errorElement = wrapper.find(settings.error_tag + '.' + settings.error_class.replace(/ /g, '.'));
 
           if (!errorElement.length) {
-            errorElement = $('<' + settings.error_tag + '/>', {
+            errorElement = $('<' + settings.error_tag + '>', {
               "class": settings.error_class,
               text: message
             });


### PR DESCRIPTION
Quoting from https://blog.jquery.com/2020/04/10/jquery-3-5-0-released/

> ### Security Fix
> The main change in this release is a security fix, and it’s possible you will need to change your own code to adapt. Here’s why: jQuery used a regex in its `jQuery.htmlPrefilter` method to ensure that all closing tags were XHTML-compliant when passed to methods. For example, this prefilter ensured that a call like jQuery(`"<div class='hot' />"`) is actually converted to jQuery(`"<div class='hot'></div>"`). Recently, an issue was reported that demonstrated the regex could introduce a cross-site scripting (XSS) vulnerability.
>
> The HTML parser in jQuery <=3.4.1 usually did the right thing, but there were edge cases where parsing would have unintended consequences. The jQuery team agreed it was necessary to fix this in a minor release, even though some code relies on the previous behavior and may break. The jQuery.htmlPrefilter function does not use a regex in 3.5.0 and passes the string through unchanged.

This PR:
- Tests against jQuery 3.5.0
- Fixes JS tests
- Fixes Ruby tests
- Changes the default `input_tag` and `label_tag` to XHTML-compliant tags