### PR TITLE
Support finding nested `:error`

### DIFF
--- a/lib/client_side_validations/simple_form/form_builder.rb
+++ b/lib/client_side_validations/simple_form/form_builder.rb
@@ -28,11 +28,23 @@ module ClientSideValidations
       private
 
       def wrapper_error_component
-        if wrapper.components.map(&:namespace).include?(:error)
+        if wrapper_namespaces(wrapper, []).include?(:error)
           wrapper.find(:error)
         else
           wrapper.find(:full_error)
         end
+      end
+
+      def wrapper_namespaces(component, namespaces)
+        return namespaces if component.instance_of?(::SimpleForm::Wrappers::Leaf)
+
+        namespaces << component.namespace
+
+        child_component_namespaces = component.components.map do |child_component|
+          wrapper_namespaces(child_component, namespaces)
+        end
+
+        namespaces + child_component_namespaces
       end
     end
   end

--- a/lib/client_side_validations/simple_form/form_builder.rb
+++ b/lib/client_side_validations/simple_form/form_builder.rb
@@ -28,23 +28,21 @@ module ClientSideValidations
       private
 
       def wrapper_error_component
-        if wrapper_namespaces(wrapper, []).include?(:error)
+        if namespace_present?(wrapper, :error)
           wrapper.find(:error)
         else
           wrapper.find(:full_error)
         end
       end
 
-      def wrapper_namespaces(component, namespaces)
-        return namespaces if component.instance_of?(::SimpleForm::Wrappers::Leaf)
+      def namespace_present?(component, namespace)
+        return true if component.namespace == namespace
 
-        namespaces << component.namespace
-
-        child_component_namespaces = component.components.map do |child_component|
-          wrapper_namespaces(child_component, namespaces)
+        component.try(:components)&.each do |child_component|
+          return true if namespace_present?(child_component, namespace)
         end
 
-        namespaces + child_component_namespaces
+        false
       end
     end
   end

--- a/test/simple_form/cases/helper.rb
+++ b/test/simple_form/cases/helper.rb
@@ -18,6 +18,14 @@ def custom_wrapper_with_full_error
   end
 end
 
+def custom_wrapper_with_nested_error
+  SimpleForm.build tag: :div, class: :input, error_class: :field_with_errors do |b|
+    b.wrapper tag: :div do |b_nested|
+      b_nested.use :error, wrap_with: { tag: :span, class: :error }
+    end
+  end
+end
+
 def custom_wrapper_with_error_and_full_error
   SimpleForm.build tag: :div, class: :input, error_class: :field_with_errors do |b|
     b.use :error, wrap_with: { tag: :span, class: :error }

--- a/test/simple_form/cases/test_form_builder.rb
+++ b/test/simple_form/cases/test_form_builder.rb
@@ -35,6 +35,13 @@ module ClientSideValidations
         end
       end
 
+      def test_client_side_form_js_hash_with_nested_error
+        swap_wrapper(custom_wrapper_with_nested_error) do
+          builder = ::SimpleForm::FormBuilder.new(:user, nil, {}, {})
+          assert_equal expected_hash, builder.client_side_form_settings({}, nil)
+        end
+      end
+
       def test_client_side_form_js_hash_with_custom_wrapper
         expected = expected_hash.merge(wrapper: :bootstrap)
 


### PR DESCRIPTION
Hi there 👋 

I want to start by saying thank you for building and maintaining this gem. It has helped my team immensely in building robust frontend error handling.

My team is currently on an older version of `client_side_validations-simple_form`, version `6.10.0`. We would like to upgrade to the latest version of the gem, but are having issues when upgrading to `10.0.0` onwards.

In my team's codebase, we define some custom `SimpleForm` wrappers with a nested error component. It seems with #76, the namespaces of nested components are not traversed, meaning that if the error is nested, `client_side_validations-simple_form` will default to `wrapper.find(:full_error)`, even though `:error` is defined.

It looks like a similar issue was brought up in #56, but it's unclear to me what the outcome there was. I decided to create a Pull Request demonstrating a failing test case, which is fixed by traversing all the sub-component namespaces.

To be clear, I'm not sure about the performance of this traversal for larger forms. And I'm also not necessarily looking to merge this either. I'm just trying to understand if this behaviour that exists from `10.0.0` onwards was intentional, and used the Pull Request to demonstrate the issue.

If you would prefer me to open up a bug report for this, I'm happy to do so as well.