### PR TITLE
Remove jQuery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## main / unreleased
 
+* [FEATURE] Do not require jQuery
 * [ENHANCEMENT] Test against Ruby 3.2
-* [ENHANCEMENT] Test against jQuery 3.7.0 by default
 * [ENHANCEMENT] Update QUnit to 2.19.4
 
 ## 15.0.0 / 2022-09-18

--- a/dist/simple-form.bootstrap4.esm.js
+++ b/dist/simple-form.bootstrap4.esm.js
@@ -1,49 +1,88 @@
 /*!
- * Client Side Validations Simple Form JS (Default) - v0.3.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Default) - v0.4.0 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2023 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
-import jQuery from 'jquery';
 import ClientSideValidations from '@client-side-validations/client-side-validations';
+
+function _toConsumableArray(arr) {
+  return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread();
+}
+function _arrayWithoutHoles(arr) {
+  if (Array.isArray(arr)) return _arrayLikeToArray(arr);
+}
+function _iterableToArray(iter) {
+  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+}
+function _unsupportedIterableToArray(o, minLen) {
+  if (!o) return;
+  if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+  var n = Object.prototype.toString.call(o).slice(8, -1);
+  if (n === "Object" && o.constructor) n = o.constructor.name;
+  if (n === "Map" || n === "Set") return Array.from(o);
+  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+}
+function _arrayLikeToArray(arr, len) {
+  if (len == null || len > arr.length) len = arr.length;
+  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+  return arr2;
+}
+function _nonIterableSpread() {
+  throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+}
+
+var addClass = function addClass(element, customClass) {
+  if (customClass) {
+    var _element$classList;
+    (_element$classList = element.classList).add.apply(_element$classList, _toConsumableArray(customClass.split(' ')));
+  }
+};
+var removeClass = function removeClass(element, customClass) {
+  if (customClass) {
+    var _element$classList2;
+    (_element$classList2 = element.classList).remove.apply(_element$classList2, _toConsumableArray(customClass.split(' ')));
+  }
+};
 
 ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
   add: function add($element, settings, message) {
-    this.wrapper(settings.wrapper).add.call(this, $element, settings, message);
+    this.wrapper(settings.wrapper).add.call(this, $element[0], settings, message);
   },
   remove: function remove($element, settings) {
-    this.wrapper(settings.wrapper).remove.call(this, $element, settings);
+    this.wrapper(settings.wrapper).remove.call(this, $element[0], settings);
   },
   wrapper: function wrapper(name) {
     return this.wrappers[name] || this.wrappers.default;
   },
   wrappers: {
     default: {
-      add: function add($element, settings, message) {
-        var $wrapperElement = $element.parent();
-        var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".invalid-feedback"));
-        if (!$errorElement.length) {
-          var $formTextElement = $wrapperElement.find('.form-text');
-          $errorElement = jQuery("<".concat(settings.error_tag, ">"), {
-            class: 'invalid-feedback',
-            text: message
-          });
-          if ($formTextElement.length) {
-            $formTextElement.before($errorElement);
+      add: function add(element, settings, message) {
+        var wrapperElement = element.parentElement;
+        var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".invalid-feedback"));
+        if (!errorElement) {
+          var formTextElement = wrapperElement.querySelector('.form-text');
+          errorElement = document.createElement(settings.error_tag);
+          addClass(errorElement, 'invalid-feedback');
+          errorElement.textContent = message;
+          if (formTextElement) {
+            formTextElement.before(errorElement);
           } else {
-            $wrapperElement.append($errorElement);
+            wrapperElement.appendChild(errorElement);
           }
         }
-        $wrapperElement.addClass(settings.wrapper_error_class);
-        $element.addClass('is-invalid');
-        $errorElement.text(message);
+        addClass(wrapperElement, settings.wrapper_error_class);
+        addClass(element, 'is-invalid');
+        errorElement.textContent = message;
       },
-      remove: function remove($element, settings) {
-        var $wrapperElement = $element.parent();
-        var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".invalid-feedback"));
-        $wrapperElement.removeClass(settings.wrapper_error_class);
-        $element.removeClass('is-invalid');
-        $errorElement.remove();
+      remove: function remove(element, settings) {
+        var wrapperElement = element.parentElement;
+        var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".invalid-feedback"));
+        removeClass(wrapperElement, settings.wrapper_error_class);
+        removeClass(element, 'is-invalid');
+        if (errorElement) {
+          errorElement.remove();
+        }
       }
     }
   }

--- a/dist/simple-form.bootstrap4.js
+++ b/dist/simple-form.bootstrap4.js
@@ -1,52 +1,92 @@
 /*!
- * Client Side Validations Simple Form JS (Bootstrap 4+) - v0.3.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Bootstrap 4+) - v0.4.0 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2023 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('jquery'), require('@client-side-validations/client-side-validations')) :
-  typeof define === 'function' && define.amd ? define(['jquery', '@client-side-validations/client-side-validations'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.jQuery, global.ClientSideValidations));
-})(this, (function (jQuery, ClientSideValidations) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('@client-side-validations/client-side-validations')) :
+  typeof define === 'function' && define.amd ? define(['@client-side-validations/client-side-validations'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.ClientSideValidations));
+})(this, (function (ClientSideValidations) { 'use strict';
+
+  function _toConsumableArray(arr) {
+    return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread();
+  }
+  function _arrayWithoutHoles(arr) {
+    if (Array.isArray(arr)) return _arrayLikeToArray(arr);
+  }
+  function _iterableToArray(iter) {
+    if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+  }
+  function _unsupportedIterableToArray(o, minLen) {
+    if (!o) return;
+    if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+    var n = Object.prototype.toString.call(o).slice(8, -1);
+    if (n === "Object" && o.constructor) n = o.constructor.name;
+    if (n === "Map" || n === "Set") return Array.from(o);
+    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+  }
+  function _arrayLikeToArray(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+    for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+    return arr2;
+  }
+  function _nonIterableSpread() {
+    throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+
+  var addClass = function addClass(element, customClass) {
+    if (customClass) {
+      var _element$classList;
+      (_element$classList = element.classList).add.apply(_element$classList, _toConsumableArray(customClass.split(' ')));
+    }
+  };
+  var removeClass = function removeClass(element, customClass) {
+    if (customClass) {
+      var _element$classList2;
+      (_element$classList2 = element.classList).remove.apply(_element$classList2, _toConsumableArray(customClass.split(' ')));
+    }
+  };
 
   ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
     add: function add($element, settings, message) {
-      this.wrapper(settings.wrapper).add.call(this, $element, settings, message);
+      this.wrapper(settings.wrapper).add.call(this, $element[0], settings, message);
     },
     remove: function remove($element, settings) {
-      this.wrapper(settings.wrapper).remove.call(this, $element, settings);
+      this.wrapper(settings.wrapper).remove.call(this, $element[0], settings);
     },
     wrapper: function wrapper(name) {
       return this.wrappers[name] || this.wrappers.default;
     },
     wrappers: {
       default: {
-        add: function add($element, settings, message) {
-          var $wrapperElement = $element.parent();
-          var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".invalid-feedback"));
-          if (!$errorElement.length) {
-            var $formTextElement = $wrapperElement.find('.form-text');
-            $errorElement = jQuery("<".concat(settings.error_tag, ">"), {
-              class: 'invalid-feedback',
-              text: message
-            });
-            if ($formTextElement.length) {
-              $formTextElement.before($errorElement);
+        add: function add(element, settings, message) {
+          var wrapperElement = element.parentElement;
+          var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".invalid-feedback"));
+          if (!errorElement) {
+            var formTextElement = wrapperElement.querySelector('.form-text');
+            errorElement = document.createElement(settings.error_tag);
+            addClass(errorElement, 'invalid-feedback');
+            errorElement.textContent = message;
+            if (formTextElement) {
+              formTextElement.before(errorElement);
             } else {
-              $wrapperElement.append($errorElement);
+              wrapperElement.appendChild(errorElement);
             }
           }
-          $wrapperElement.addClass(settings.wrapper_error_class);
-          $element.addClass('is-invalid');
-          $errorElement.text(message);
+          addClass(wrapperElement, settings.wrapper_error_class);
+          addClass(element, 'is-invalid');
+          errorElement.textContent = message;
         },
-        remove: function remove($element, settings) {
-          var $wrapperElement = $element.parent();
-          var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".invalid-feedback"));
-          $wrapperElement.removeClass(settings.wrapper_error_class);
-          $element.removeClass('is-invalid');
-          $errorElement.remove();
+        remove: function remove(element, settings) {
+          var wrapperElement = element.parentElement;
+          var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".invalid-feedback"));
+          removeClass(wrapperElement, settings.wrapper_error_class);
+          removeClass(element, 'is-invalid');
+          if (errorElement) {
+            errorElement.remove();
+          }
         }
       }
     }

--- a/dist/simple-form.esm.js
+++ b/dist/simple-form.esm.js
@@ -1,42 +1,81 @@
 /*!
- * Client Side Validations Simple Form JS (Default) - v0.3.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Default) - v0.4.0 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2023 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
-import jQuery from 'jquery';
 import ClientSideValidations from '@client-side-validations/client-side-validations';
+
+function _toConsumableArray(arr) {
+  return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread();
+}
+function _arrayWithoutHoles(arr) {
+  if (Array.isArray(arr)) return _arrayLikeToArray(arr);
+}
+function _iterableToArray(iter) {
+  if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+}
+function _unsupportedIterableToArray(o, minLen) {
+  if (!o) return;
+  if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+  var n = Object.prototype.toString.call(o).slice(8, -1);
+  if (n === "Object" && o.constructor) n = o.constructor.name;
+  if (n === "Map" || n === "Set") return Array.from(o);
+  if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+}
+function _arrayLikeToArray(arr, len) {
+  if (len == null || len > arr.length) len = arr.length;
+  for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+  return arr2;
+}
+function _nonIterableSpread() {
+  throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+}
+
+var addClass = function addClass(element, customClass) {
+  if (customClass) {
+    var _element$classList;
+    (_element$classList = element.classList).add.apply(_element$classList, _toConsumableArray(customClass.split(' ')));
+  }
+};
+var removeClass = function removeClass(element, customClass) {
+  if (customClass) {
+    var _element$classList2;
+    (_element$classList2 = element.classList).remove.apply(_element$classList2, _toConsumableArray(customClass.split(' ')));
+  }
+};
 
 ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
   add: function add($element, settings, message) {
-    this.wrapper(settings.wrapper).add.call(this, $element, settings, message);
+    this.wrapper(settings.wrapper).add.call(this, $element[0], settings, message);
   },
   remove: function remove($element, settings) {
-    this.wrapper(settings.wrapper).remove.call(this, $element, settings);
+    this.wrapper(settings.wrapper).remove.call(this, $element[0], settings);
   },
   wrapper: function wrapper(name) {
     return this.wrappers[name] || this.wrappers.default;
   },
   wrappers: {
     default: {
-      add: function add($element, settings, message) {
-        var $wrapperElement = $element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
-        var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
-        if (!$errorElement.length) {
-          $errorElement = jQuery("<".concat(settings.error_tag, ">"), {
-            class: settings.error_class,
-            text: message
-          });
-          $wrapperElement.append($errorElement);
+      add: function add(element, settings, message) {
+        var wrapperElement = element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
+        var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
+        if (!errorElement) {
+          errorElement = document.createElement(settings.error_tag);
+          addClass(errorElement, settings.error_class);
+          errorElement.textContent = message;
+          wrapperElement.appendChild(errorElement);
         }
-        $wrapperElement.addClass(settings.wrapper_error_class);
-        $errorElement.text(message);
+        addClass(wrapperElement, settings.wrapper_error_class);
+        errorElement.textContent = message;
       },
-      remove: function remove($element, settings) {
-        var $wrapperElement = $element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.'), ".").concat(settings.wrapper_error_class));
-        var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
-        $wrapperElement.removeClass(settings.wrapper_error_class);
-        $errorElement.remove();
+      remove: function remove(element, settings) {
+        var wrapperElement = element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
+        var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
+        removeClass(wrapperElement, settings.wrapper_error_class);
+        if (errorElement) {
+          errorElement.remove();
+        }
       }
     }
   }

--- a/dist/simple-form.js
+++ b/dist/simple-form.js
@@ -1,45 +1,85 @@
 /*!
- * Client Side Validations Simple Form JS (Default) - v0.3.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Default) - v0.4.0 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2023 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('jquery'), require('@client-side-validations/client-side-validations')) :
-  typeof define === 'function' && define.amd ? define(['jquery', '@client-side-validations/client-side-validations'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.jQuery, global.ClientSideValidations));
-})(this, (function (jQuery, ClientSideValidations) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('@client-side-validations/client-side-validations')) :
+  typeof define === 'function' && define.amd ? define(['@client-side-validations/client-side-validations'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.ClientSideValidations));
+})(this, (function (ClientSideValidations) { 'use strict';
+
+  function _toConsumableArray(arr) {
+    return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread();
+  }
+  function _arrayWithoutHoles(arr) {
+    if (Array.isArray(arr)) return _arrayLikeToArray(arr);
+  }
+  function _iterableToArray(iter) {
+    if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+  }
+  function _unsupportedIterableToArray(o, minLen) {
+    if (!o) return;
+    if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+    var n = Object.prototype.toString.call(o).slice(8, -1);
+    if (n === "Object" && o.constructor) n = o.constructor.name;
+    if (n === "Map" || n === "Set") return Array.from(o);
+    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+  }
+  function _arrayLikeToArray(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+    for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+    return arr2;
+  }
+  function _nonIterableSpread() {
+    throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+
+  var addClass = function addClass(element, customClass) {
+    if (customClass) {
+      var _element$classList;
+      (_element$classList = element.classList).add.apply(_element$classList, _toConsumableArray(customClass.split(' ')));
+    }
+  };
+  var removeClass = function removeClass(element, customClass) {
+    if (customClass) {
+      var _element$classList2;
+      (_element$classList2 = element.classList).remove.apply(_element$classList2, _toConsumableArray(customClass.split(' ')));
+    }
+  };
 
   ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
     add: function add($element, settings, message) {
-      this.wrapper(settings.wrapper).add.call(this, $element, settings, message);
+      this.wrapper(settings.wrapper).add.call(this, $element[0], settings, message);
     },
     remove: function remove($element, settings) {
-      this.wrapper(settings.wrapper).remove.call(this, $element, settings);
+      this.wrapper(settings.wrapper).remove.call(this, $element[0], settings);
     },
     wrapper: function wrapper(name) {
       return this.wrappers[name] || this.wrappers.default;
     },
     wrappers: {
       default: {
-        add: function add($element, settings, message) {
-          var $wrapperElement = $element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
-          var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
-          if (!$errorElement.length) {
-            $errorElement = jQuery("<".concat(settings.error_tag, ">"), {
-              class: settings.error_class,
-              text: message
-            });
-            $wrapperElement.append($errorElement);
+        add: function add(element, settings, message) {
+          var wrapperElement = element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
+          var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
+          if (!errorElement) {
+            errorElement = document.createElement(settings.error_tag);
+            addClass(errorElement, settings.error_class);
+            errorElement.textContent = message;
+            wrapperElement.appendChild(errorElement);
           }
-          $wrapperElement.addClass(settings.wrapper_error_class);
-          $errorElement.text(message);
+          addClass(wrapperElement, settings.wrapper_error_class);
+          errorElement.textContent = message;
         },
-        remove: function remove($element, settings) {
-          var $wrapperElement = $element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.'), ".").concat(settings.wrapper_error_class));
-          var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
-          $wrapperElement.removeClass(settings.wrapper_error_class);
-          $errorElement.remove();
+        remove: function remove(element, settings) {
+          var wrapperElement = element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
+          var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
+          removeClass(wrapperElement, settings.wrapper_error_class);
+          if (errorElement) {
+            errorElement.remove();
+          }
         }
       }
     }

--- a/lib/client_side_validations/simple_form/version.rb
+++ b/lib/client_side_validations/simple_form/version.rb
@@ -2,6 +2,6 @@
 
 module ClientSideValidations
   module SimpleForm
-    VERSION = '15.0.0'
+    VERSION = '16.0.0'
   end
 end

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "standard": "^17.1.0"
   },
   "peerDependencies": {
-    "@client-side-validations/client-side-validations": ">= 0.2.0 < 0.4.0",
-    "jquery": ">= 1.12.4 < 4.0.0"
+    "@client-side-validations/client-side-validations": ">= 0.2.0 < 0.4.0"
   },
   "main": "dist/simple-form.js",
   "module": "dist/simple-form.esm.js",
@@ -68,7 +67,7 @@
       "/vendor/"
     ]
   },
-  "version": "0.3.1",
+  "version": "0.4.0",
   "directories": {
     "lib": "lib",
     "test": "test"

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -18,14 +18,13 @@ const banner = (formBuilderName) => `/*!
 
 const umdModuleConfig = (inputFileName, outputModuleFileName, outputVendorFileName, formBuilderName) => ({
   input: `src/${inputFileName}`,
-  external: ['jquery', '@client-side-validations/client-side-validations'],
+  external: ['@client-side-validations/client-side-validations'],
   output: [
     {
       file: outputModuleFileName,
       banner: banner(formBuilderName),
       format: 'umd',
       globals: {
-        jquery: 'jQuery',
         '@client-side-validations/client-side-validations': 'ClientSideValidations'
       }
     }
@@ -45,7 +44,7 @@ const umdModuleConfig = (inputFileName, outputModuleFileName, outputVendorFileNa
 
 const esModuleConfig = (inputFileName, outputModuleFileName, formBuilderName) => ({
   input: `src/${inputFileName}`,
-  external: ['jquery', '@client-side-validations/client-side-validations'],
+  external: ['@client-side-validations/client-side-validations'],
   output: [
     {
       file: outputModuleFileName,

--- a/src/index.bootstrap4.js
+++ b/src/index.bootstrap4.js
@@ -1,12 +1,12 @@
-import jQuery from 'jquery'
 import ClientSideValidations from '@client-side-validations/client-side-validations'
+import { addClass, removeClass } from './utils'
 
 ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
   add: function ($element, settings, message) {
-    this.wrapper(settings.wrapper).add.call(this, $element, settings, message)
+    this.wrapper(settings.wrapper).add.call(this, $element[0], settings, message)
   },
   remove: function ($element, settings) {
-    this.wrapper(settings.wrapper).remove.call(this, $element, settings)
+    this.wrapper(settings.wrapper).remove.call(this, $element[0], settings)
   },
   wrapper: function (name) {
     return this.wrappers[name] || this.wrappers.default
@@ -14,33 +14,40 @@ ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
 
   wrappers: {
     default: {
-      add ($element, settings, message) {
-        const $wrapperElement = $element.parent()
-        let $errorElement = $wrapperElement.find(`${settings.error_tag}.invalid-feedback`)
+      add (element, settings, message) {
+        const wrapperElement = element.parentElement
+        let errorElement = wrapperElement.querySelector(`${settings.error_tag}.invalid-feedback`)
 
-        if (!$errorElement.length) {
-          const $formTextElement = $wrapperElement.find('.form-text')
-          $errorElement = jQuery(`<${settings.error_tag}>`, { class: 'invalid-feedback', text: message })
+        if (!errorElement) {
+          const formTextElement = wrapperElement.querySelector('.form-text')
 
-          if ($formTextElement.length) {
-            $formTextElement.before($errorElement)
+          errorElement = document.createElement(settings.error_tag)
+          addClass(errorElement, 'invalid-feedback')
+          errorElement.textContent = message
+
+          if (formTextElement) {
+            formTextElement.before(errorElement)
           } else {
-            $wrapperElement.append($errorElement)
+            wrapperElement.appendChild(errorElement)
           }
         }
 
-        $wrapperElement.addClass(settings.wrapper_error_class)
-        $element.addClass('is-invalid')
-        $errorElement.text(message)
+        addClass(wrapperElement, settings.wrapper_error_class)
+        addClass(element, 'is-invalid')
+
+        errorElement.textContent = message
       },
 
-      remove ($element, settings) {
-        const $wrapperElement = $element.parent()
-        const $errorElement = $wrapperElement.find(`${settings.error_tag}.invalid-feedback`)
+      remove (element, settings) {
+        const wrapperElement = element.parentElement
+        const errorElement = wrapperElement.querySelector(`${settings.error_tag}.invalid-feedback`)
 
-        $wrapperElement.removeClass(settings.wrapper_error_class)
-        $element.removeClass('is-invalid')
-        $errorElement.remove()
+        removeClass(wrapperElement, settings.wrapper_error_class)
+        removeClass(element, 'is-invalid')
+
+        if (errorElement) {
+          errorElement.remove()
+        }
       }
     }
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,12 @@
-import jQuery from 'jquery'
 import ClientSideValidations from '@client-side-validations/client-side-validations'
+import { addClass, removeClass } from './utils'
 
 ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
   add: function ($element, settings, message) {
-    this.wrapper(settings.wrapper).add.call(this, $element, settings, message)
+    this.wrapper(settings.wrapper).add.call(this, $element[0], settings, message)
   },
   remove: function ($element, settings) {
-    this.wrapper(settings.wrapper).remove.call(this, $element, settings)
+    this.wrapper(settings.wrapper).remove.call(this, $element[0], settings)
   },
   wrapper: function (name) {
     return this.wrappers[name] || this.wrappers.default
@@ -14,25 +14,32 @@ ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
 
   wrappers: {
     default: {
-      add ($element, settings, message) {
-        const $wrapperElement = $element.closest(`${settings.wrapper_tag}.${settings.wrapper_class.replace(/ /g, '.')}`)
-        let $errorElement = $wrapperElement.find(`${settings.error_tag}.${settings.error_class.replace(/ /g, '.')}`)
+      add (element, settings, message) {
+        const wrapperElement = element.closest(`${settings.wrapper_tag}.${settings.wrapper_class.replace(/ /g, '.')}`)
+        let errorElement = wrapperElement.querySelector(`${settings.error_tag}.${settings.error_class.replace(/ /g, '.')}`)
 
-        if (!$errorElement.length) {
-          $errorElement = jQuery(`<${settings.error_tag}>`, { class: settings.error_class, text: message })
-          $wrapperElement.append($errorElement)
+        if (!errorElement) {
+          errorElement = document.createElement(settings.error_tag)
+          addClass(errorElement, settings.error_class)
+          errorElement.textContent = message
+
+          wrapperElement.appendChild(errorElement)
         }
 
-        $wrapperElement.addClass(settings.wrapper_error_class)
-        $errorElement.text(message)
+        addClass(wrapperElement, settings.wrapper_error_class)
+
+        errorElement.textContent = message
       },
 
-      remove ($element, settings) {
-        const $wrapperElement = $element.closest(`${settings.wrapper_tag}.${settings.wrapper_class.replace(/ /g, '.')}.${settings.wrapper_error_class}`)
-        const $errorElement = $wrapperElement.find(`${settings.error_tag}.${settings.error_class.replace(/ /g, '.')}`)
+      remove (element, settings) {
+        const wrapperElement = element.closest(`${settings.wrapper_tag}.${settings.wrapper_class.replace(/ /g, '.')}`)
+        const errorElement = wrapperElement.querySelector(`${settings.error_tag}.${settings.error_class.replace(/ /g, '.')}`)
 
-        $wrapperElement.removeClass(settings.wrapper_error_class)
-        $errorElement.remove()
+        removeClass(wrapperElement, settings.wrapper_error_class)
+
+        if (errorElement) {
+          errorElement.remove()
+        }
       }
     }
   }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,16 @@
+export const addClass = (element, customClass) => {
+  if (customClass) {
+    element.classList.add(...customClass.split(' '))
+  }
+}
+
+export const removeClass = (element, customClass) => {
+  if (customClass) {
+    element.classList.remove(...customClass.split(' '))
+  }
+}
+
+export default {
+  addClass,
+  removeClass
+}

--- a/test/javascript/public/test/settings.js
+++ b/test/javascript/public/test/settings.js
@@ -1,12 +1,5 @@
 QUnit.config.autostart = window.location.search.search('autostart=false') < 0
 
-QUnit.config.urlConfig.push({
-  id: 'jquery',
-  label: 'jQuery version',
-  value: ['3.7.0', '3.7.0.slim', '3.6.4', '3.6.4.slim', '3.5.1', '3.5.1.slim', '3.4.1', '3.4.1.slim', '3.3.1', '3.3.1.slim', '3.2.1', '3.2.1.slim', '3.1.1', '3.1.1.slim', '3.0.0', '3.0.0.slim', '2.2.4', '2.1.4', '2.0.3', '1.12.4', '1.11.3'],
-  tooltip: 'What jQuery Core version to test against'
-})
-
 /* Hijacks normal form submit; lets it submit to an iframe to prevent
  * navigating away from the test suite
  */

--- a/test/javascript/server.rb
+++ b/test/javascript/server.rb
@@ -33,7 +33,7 @@ use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../
 use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../', $LOAD_PATH.find { |p| p.include?('jquery-rails') })
 use AssetPath, urls: ['/vendor/assets/javascripts'], root: rails_validations_path.full_gem_path
 
-DEFAULT_JQUERY_VERSION = '3.7.0'
+DEFAULT_JQUERY_VERSION = '3.7.0.slim'
 QUNIT_VERSION          = '2.19.4'
 
 helpers do

--- a/vendor/assets/javascripts/rails.validations.simple_form.bootstrap4.js
+++ b/vendor/assets/javascripts/rails.validations.simple_form.bootstrap4.js
@@ -1,52 +1,92 @@
 /*!
- * Client Side Validations Simple Form JS (Bootstrap 4+) - v0.3.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Bootstrap 4+) - v0.4.0 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2023 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('jquery'), require('@client-side-validations/client-side-validations')) :
-  typeof define === 'function' && define.amd ? define(['jquery', '@client-side-validations/client-side-validations'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.jQuery, global.ClientSideValidations));
-})(this, (function (jQuery, ClientSideValidations) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('@client-side-validations/client-side-validations')) :
+  typeof define === 'function' && define.amd ? define(['@client-side-validations/client-side-validations'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.ClientSideValidations));
+})(this, (function (ClientSideValidations) { 'use strict';
+
+  function _toConsumableArray(arr) {
+    return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread();
+  }
+  function _arrayWithoutHoles(arr) {
+    if (Array.isArray(arr)) return _arrayLikeToArray(arr);
+  }
+  function _iterableToArray(iter) {
+    if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+  }
+  function _unsupportedIterableToArray(o, minLen) {
+    if (!o) return;
+    if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+    var n = Object.prototype.toString.call(o).slice(8, -1);
+    if (n === "Object" && o.constructor) n = o.constructor.name;
+    if (n === "Map" || n === "Set") return Array.from(o);
+    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+  }
+  function _arrayLikeToArray(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+    for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+    return arr2;
+  }
+  function _nonIterableSpread() {
+    throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+
+  var addClass = function addClass(element, customClass) {
+    if (customClass) {
+      var _element$classList;
+      (_element$classList = element.classList).add.apply(_element$classList, _toConsumableArray(customClass.split(' ')));
+    }
+  };
+  var removeClass = function removeClass(element, customClass) {
+    if (customClass) {
+      var _element$classList2;
+      (_element$classList2 = element.classList).remove.apply(_element$classList2, _toConsumableArray(customClass.split(' ')));
+    }
+  };
 
   ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
     add: function add($element, settings, message) {
-      this.wrapper(settings.wrapper).add.call(this, $element, settings, message);
+      this.wrapper(settings.wrapper).add.call(this, $element[0], settings, message);
     },
     remove: function remove($element, settings) {
-      this.wrapper(settings.wrapper).remove.call(this, $element, settings);
+      this.wrapper(settings.wrapper).remove.call(this, $element[0], settings);
     },
     wrapper: function wrapper(name) {
       return this.wrappers[name] || this.wrappers.default;
     },
     wrappers: {
       default: {
-        add: function add($element, settings, message) {
-          var $wrapperElement = $element.parent();
-          var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".invalid-feedback"));
-          if (!$errorElement.length) {
-            var $formTextElement = $wrapperElement.find('.form-text');
-            $errorElement = jQuery("<".concat(settings.error_tag, ">"), {
-              class: 'invalid-feedback',
-              text: message
-            });
-            if ($formTextElement.length) {
-              $formTextElement.before($errorElement);
+        add: function add(element, settings, message) {
+          var wrapperElement = element.parentElement;
+          var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".invalid-feedback"));
+          if (!errorElement) {
+            var formTextElement = wrapperElement.querySelector('.form-text');
+            errorElement = document.createElement(settings.error_tag);
+            addClass(errorElement, 'invalid-feedback');
+            errorElement.textContent = message;
+            if (formTextElement) {
+              formTextElement.before(errorElement);
             } else {
-              $wrapperElement.append($errorElement);
+              wrapperElement.appendChild(errorElement);
             }
           }
-          $wrapperElement.addClass(settings.wrapper_error_class);
-          $element.addClass('is-invalid');
-          $errorElement.text(message);
+          addClass(wrapperElement, settings.wrapper_error_class);
+          addClass(element, 'is-invalid');
+          errorElement.textContent = message;
         },
-        remove: function remove($element, settings) {
-          var $wrapperElement = $element.parent();
-          var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".invalid-feedback"));
-          $wrapperElement.removeClass(settings.wrapper_error_class);
-          $element.removeClass('is-invalid');
-          $errorElement.remove();
+        remove: function remove(element, settings) {
+          var wrapperElement = element.parentElement;
+          var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".invalid-feedback"));
+          removeClass(wrapperElement, settings.wrapper_error_class);
+          removeClass(element, 'is-invalid');
+          if (errorElement) {
+            errorElement.remove();
+          }
         }
       }
     }

--- a/vendor/assets/javascripts/rails.validations.simple_form.js
+++ b/vendor/assets/javascripts/rails.validations.simple_form.js
@@ -1,45 +1,85 @@
 /*!
- * Client Side Validations Simple Form JS (Default) - v0.3.1 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
+ * Client Side Validations Simple Form JS (Default) - v0.4.0 (https://github.com/DavyJonesLocker/client_side_validations-simple_form)
  * Copyright (c) 2023 Geremia Taglialatela, Brian Cardarella
  * Licensed under MIT (https://opensource.org/licenses/mit-license.php)
  */
 
 (function (global, factory) {
-  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('jquery'), require('@client-side-validations/client-side-validations')) :
-  typeof define === 'function' && define.amd ? define(['jquery', '@client-side-validations/client-side-validations'], factory) :
-  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.jQuery, global.ClientSideValidations));
-})(this, (function (jQuery, ClientSideValidations) { 'use strict';
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('@client-side-validations/client-side-validations')) :
+  typeof define === 'function' && define.amd ? define(['@client-side-validations/client-side-validations'], factory) :
+  (global = typeof globalThis !== 'undefined' ? globalThis : global || self, factory(global.ClientSideValidations));
+})(this, (function (ClientSideValidations) { 'use strict';
+
+  function _toConsumableArray(arr) {
+    return _arrayWithoutHoles(arr) || _iterableToArray(arr) || _unsupportedIterableToArray(arr) || _nonIterableSpread();
+  }
+  function _arrayWithoutHoles(arr) {
+    if (Array.isArray(arr)) return _arrayLikeToArray(arr);
+  }
+  function _iterableToArray(iter) {
+    if (typeof Symbol !== "undefined" && iter[Symbol.iterator] != null || iter["@@iterator"] != null) return Array.from(iter);
+  }
+  function _unsupportedIterableToArray(o, minLen) {
+    if (!o) return;
+    if (typeof o === "string") return _arrayLikeToArray(o, minLen);
+    var n = Object.prototype.toString.call(o).slice(8, -1);
+    if (n === "Object" && o.constructor) n = o.constructor.name;
+    if (n === "Map" || n === "Set") return Array.from(o);
+    if (n === "Arguments" || /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)) return _arrayLikeToArray(o, minLen);
+  }
+  function _arrayLikeToArray(arr, len) {
+    if (len == null || len > arr.length) len = arr.length;
+    for (var i = 0, arr2 = new Array(len); i < len; i++) arr2[i] = arr[i];
+    return arr2;
+  }
+  function _nonIterableSpread() {
+    throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.");
+  }
+
+  var addClass = function addClass(element, customClass) {
+    if (customClass) {
+      var _element$classList;
+      (_element$classList = element.classList).add.apply(_element$classList, _toConsumableArray(customClass.split(' ')));
+    }
+  };
+  var removeClass = function removeClass(element, customClass) {
+    if (customClass) {
+      var _element$classList2;
+      (_element$classList2 = element.classList).remove.apply(_element$classList2, _toConsumableArray(customClass.split(' ')));
+    }
+  };
 
   ClientSideValidations.formBuilders['SimpleForm::FormBuilder'] = {
     add: function add($element, settings, message) {
-      this.wrapper(settings.wrapper).add.call(this, $element, settings, message);
+      this.wrapper(settings.wrapper).add.call(this, $element[0], settings, message);
     },
     remove: function remove($element, settings) {
-      this.wrapper(settings.wrapper).remove.call(this, $element, settings);
+      this.wrapper(settings.wrapper).remove.call(this, $element[0], settings);
     },
     wrapper: function wrapper(name) {
       return this.wrappers[name] || this.wrappers.default;
     },
     wrappers: {
       default: {
-        add: function add($element, settings, message) {
-          var $wrapperElement = $element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
-          var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
-          if (!$errorElement.length) {
-            $errorElement = jQuery("<".concat(settings.error_tag, ">"), {
-              class: settings.error_class,
-              text: message
-            });
-            $wrapperElement.append($errorElement);
+        add: function add(element, settings, message) {
+          var wrapperElement = element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
+          var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
+          if (!errorElement) {
+            errorElement = document.createElement(settings.error_tag);
+            addClass(errorElement, settings.error_class);
+            errorElement.textContent = message;
+            wrapperElement.appendChild(errorElement);
           }
-          $wrapperElement.addClass(settings.wrapper_error_class);
-          $errorElement.text(message);
+          addClass(wrapperElement, settings.wrapper_error_class);
+          errorElement.textContent = message;
         },
-        remove: function remove($element, settings) {
-          var $wrapperElement = $element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.'), ".").concat(settings.wrapper_error_class));
-          var $errorElement = $wrapperElement.find("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
-          $wrapperElement.removeClass(settings.wrapper_error_class);
-          $errorElement.remove();
+        remove: function remove(element, settings) {
+          var wrapperElement = element.closest("".concat(settings.wrapper_tag, ".").concat(settings.wrapper_class.replace(/ /g, '.')));
+          var errorElement = wrapperElement.querySelector("".concat(settings.error_tag, ".").concat(settings.error_class.replace(/ /g, '.')));
+          removeClass(wrapperElement, settings.wrapper_error_class);
+          if (errorElement) {
+            errorElement.remove();
+          }
         }
       }
     }


### PR DESCRIPTION
The implementation uses simple queries and class manipulation.

In view to remove it entirely from Client Side Validation, this commit removes jQuery from Simple Form extension