### PR TITLE
Prefer `require_relative` for internal requires

### DIFF
--- a/lib/client_side_validations/simple_form.rb
+++ b/lib/client_side_validations/simple_form.rb
@@ -2,9 +2,10 @@
 
 require 'simple_form'
 require 'client_side_validations'
-require 'client_side_validations/simple_form/form_builder'
+
+require_relative 'simple_form/form_builder'
 
 if defined?(Rails)
-  require 'client_side_validations/simple_form/engine'
-  require 'client_side_validations/generators/simple_form'
+  require_relative 'simple_form/engine'
+  require_relative 'generators/simple_form'
 end

--- a/test/javascript/server.rb
+++ b/test/javascript/server.rb
@@ -34,7 +34,7 @@ use AssetPath, urls: ['/vendor/assets/javascripts'], root: File.expand_path('../
 use AssetPath, urls: ['/vendor/assets/javascripts'], root: rails_validations_path.full_gem_path
 
 DEFAULT_JQUERY_VERSION = '3.7.1.slim'
-QUNIT_VERSION          = '2.21.0'
+QUNIT_VERSION          = '2.22.0'
 
 helpers do
   def jquery_version


### PR DESCRIPTION
`require_relative` is preferred over `require` for files within the same project because it uses paths relative to the current file, making code more portable and less dependent on the load path.

This change updates internal requires to use `require_relative` for consistency, performance, and improved portability.

Ref:
- rubocop/rubocop#8748